### PR TITLE
Extract words to ignore from comprehensive list in FILLERWORDS.txt

### DIFF
--- a/FILLERWORDS.txt
+++ b/FILLERWORDS.txt
@@ -1,0 +1,298 @@
+//Commented lines and empty lines are ignored
+
+//Common Prepositions: https://www.englishclub.com/vocabulary/prepositions-list.htm
+aboard
+about
+above
+across
+after
+against
+along
+amid
+among
+anti
+around
+as
+at
+before
+behind
+below
+beneath
+beside
+besides
+between
+beyond
+but
+by
+concerning
+considering
+despite
+down
+during
+except
+excepting
+excluding
+following
+for
+from
+in
+inside
+into
+like
+minus
+near
+of
+off
+on
+onto
+opposite
+outside
+over
+past
+per
+plus
+regarding
+round
+save
+since
+than
+through
+to
+toward
+towards
+under
+underneath
+unlike
+until
+up
+upon
+versus
+via
+with
+within
+without
+
+//Conjunctions: https://eslforums.com/list-of-conjunctions/
+A minute later
+Accordingly
+Actually
+After
+After a short time
+Afterward
+Also
+And
+Another
+As an example
+As a consequence
+As a result
+As soon as
+At last
+At length
+Because
+Because of this
+Before
+Besides
+Briefly
+But
+Consequently
+Conversely
+Equally
+Finally
+First
+For example
+For instance
+For this purpose
+For this reason
+Fourth
+From here on
+Further
+Furthermore
+Gradually
+Hence
+However
+In addition
+In conclusion
+In contrast
+In fact
+In short
+In spite of
+In spite of this
+In summary
+In the end
+In the meanwhile
+In the meantime
+In the same manner
+In the same way
+Just as important
+Least
+Last
+Last of all
+Lastly
+Later
+Meanwhile
+Moreover
+Nevertheless
+Next
+Nonetheless
+Now
+Nor
+Of equal importance
+On the contrary
+On the following day
+On the other hand
+Other hands
+Or
+Presently
+Second
+Similarly
+Since
+So
+Soon
+Still
+Subsequently
+Such as
+The next week
+Then
+Thereafter
+Therefore
+Third
+Thus
+To be specific
+To begin with
+To illustrate
+To repeat
+To sum up
+Too
+Ultimately
+What
+Whatever
+Whoever
+Whereas
+Whomever
+When
+While
+With this in mind
+Yet
+
+//Pronouns: https://www.thefreedictionary.com/List-of-pronouns.htm
+all
+another
+any
+anybody
+anyone
+anything
+as
+aught
+both
+each
+each other
+either
+enough
+everybody
+everyone
+everything
+few
+he
+her
+hers
+herself
+him
+himself
+his
+I
+idem
+it
+its
+itself
+many
+me
+mine
+most
+my
+myself
+naught
+neither
+no one
+nobody
+none
+nothing
+nought
+one
+one another
+other
+others
+ought
+our
+ours
+ourself
+ourselves
+several
+she
+some
+somebody
+someone
+something
+somewhat
+such
+suchlike
+that
+thee
+their
+theirs
+theirself
+theirselves
+them
+themself
+themselves
+there
+these
+they
+thine
+this
+those
+thou
+thy
+thyself
+us
+we
+what
+whatever
+whatnot
+whatsoever
+whence
+where
+whereby
+wherefrom
+wherein
+whereinto
+whereof
+whereon
+wherever
+wheresoever
+whereto
+whereunto
+wherewith
+wherewithal
+whether
+which
+whichever
+whichsoever
+who
+whoever
+whom
+whomever
+whomso
+whomsoever
+whose
+whosever
+whosesoever
+whoso
+whosoever
+ye
+yon
+yonder
+you
+your
+yours
+yourself
+yourselves

--- a/src/newsstats/NewsAnalyzer.java
+++ b/src/newsstats/NewsAnalyzer.java
@@ -4,7 +4,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class NewsAnalyzer {
-    public static final String[] IGNORED_WORDS = {"at", "in", "to", "the", "of", "on", "after", "as", "a"};
     private HashMap<String, WordCount> _wcMap = new HashMap<String, WordCount>();
     private ArrayList<String> _newsList = null;
 
@@ -13,7 +12,7 @@ public class NewsAnalyzer {
     }
 
     public void countWords() {
-        List<String> iwList = Arrays.asList(IGNORED_WORDS);
+        List<String> iwList = getIgnoredWords();
 
         for (int n = 0; n < _newsList.size(); n++) {
             newsstr = _newsList.get(n);
@@ -32,6 +31,25 @@ public class NewsAnalyzer {
             }
         }
 
+    }
+
+    public static List<String> getIgnoredWords(){
+        List<String> result = new ArrayList<String>();
+
+        try {
+            BufferedReader in = new BufferedReader(new FileReader("FILLERWORDS.txt"));
+            String line;
+            while((line = in.readLine()) != null){
+                line = line.trim();
+                if(line.isEmpty() || (line.length()>2 && line.substring(0, 2).equals("//")))
+                    continue;
+                result.add(line);
+            }
+        } catch(Exception e){
+            e.printStackTrace();
+        }
+
+        return result;
     }
 
     public void sortWords() {


### PR DESCRIPTION
Storing and adding to a list of filler words within a class as a String array is messy and does not scale well, especially considering the volume of words you might want to ignore. To support future additions and modifications, I added "FILLERWORDS.txt" which contains a large list of pronouns, conjunctions, and prepositions, along with their sources. I also added method "getIgnoredWords" in "NewsAnalyzer.java" which reads through the .txt file, ignoring commented or empty lines, and extracts the list of filler words to ignore. This means that the list can easily be added to, searched through, and used for other classes. 
I hope that you find this pull request helpful!
- Davin