### PR TITLE
Write JavaDocs for all classes and methods besides "HttpGetAndAnalyze.java"

### DIFF
--- a/src/newsstats/AnalyzeNewsMain.java
+++ b/src/newsstats/AnalyzeNewsMain.java
@@ -2,8 +2,12 @@ package newsstats;
 
 import java.util.ArrayList;
 
+/**
+ * The AnalyzeNewsMain program implements an application that retrieves content from online news articles
+ * and analyzes them based on the frequency of key words.
+ * @author ewang26
+ */
 public class AnalyzeNewsMain {
-
 // This is the class that executes NewsByJsoup and NewsAnalyzer in order to fetch and analyze the content
 
     public static void main(String[] argv) {

--- a/src/newsstats/NewsAnalyzer.java
+++ b/src/newsstats/NewsAnalyzer.java
@@ -5,15 +5,33 @@ import java.io.FileReader;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Analyzes the textual context of a news article
+ * @author ewang26
+ */
 public class NewsAnalyzer {
 
+    /**
+     * Stores the frequency of tracked words
+     */
     private HashMap<String, WordCount> _wcMap = new HashMap<String, WordCount>();
+    /**
+     * Stores the text of a news article
+     */
     private ArrayList<String> _newsList = null;
 
+    /**
+     * Creates a new NewsAnalyzer with the specified article content
+     * @param newsList represents the text from an online article
+     */
     public NewsAnalyzer(ArrayList<String> newsList) {
         _newsList = newsList;
     }
 
+    /**
+     * Counts the frequency of important words in a news article.
+     * Ignores a predefined list of "filler" words, including prepositions, conjunctions, and pronouns.
+     */
     public void countWords() {
         List<String> iwList = getIgnoredWords();
 
@@ -36,6 +54,10 @@ public class NewsAnalyzer {
 
     }
 
+    /**
+     * Retrieves the list of words or phrases to ignore from FILLERWORDS.txt
+     * @return A List of strings representing unimportant words or phrases
+     */
     public static List<String> getIgnoredWords(){
         List<String> result = new ArrayList<String>();
 
@@ -55,16 +77,27 @@ public class NewsAnalyzer {
         return result;
     }
 
+    /**
+     * Sorts then prints the tracked words of an article in non-decreasing order by their frequency.
+     */
     public void sortWords() {
         List<WordCount> wcList = _wcMap.values().stream().collect(Collectors.toList());
         Collections.sort(wcList);
         wcList.forEach(wc -> System.out.println(wc));
     }
 
+    /**
+     * Retrieves the text of the represented news article
+     * @return An ArrayList of strings storing text
+     */
     public ArrayList<String> getNewsList() {
         return _newsList;
     }
 
+    /**
+     * Sets the content of the represented news article
+     * @param newsList An ArrayList of strings storing text
+     */
     public void setNewsList(ArrayList<String> newsList) {
         this._newsList = newsList;
     }

--- a/src/newsstats/NewsByJsoup.java
+++ b/src/newsstats/NewsByJsoup.java
@@ -9,7 +9,21 @@ import java.util.ArrayList;
 
 // this class uses jsoup instead of the Java dom parser
 
+/**
+ * The NewsByJSoup program implements the retrieval of text from online news articles using the JSoup library.
+ */
 public class NewsByJsoup {
+
+    /**
+     * Retrieves News content to analyze
+     * <p>
+     * The theURL argument must specify an existing page from a news organization's website. The tag
+     * argument must be a legitimate HTML tag with which to discern relevant content to fetch.
+     *
+     * @param theUrl a URL giving the location of the text to retrieve
+     * @param tag an HTML tag specifying the type of content to retrieve from the url
+     * @return the text requested from the URL
+     */
     public static ArrayList<String> addNewsToList(String theUrl, String tag) {
         ArrayList<String> newsList = new ArrayList<String>();
 
@@ -27,7 +41,6 @@ public class NewsByJsoup {
             ex.printStackTrace();
         }
         return newsList;
-
     }
 
 }

--- a/src/newsstats/WordCount.java
+++ b/src/newsstats/WordCount.java
@@ -1,30 +1,59 @@
 package newsstats;
 
+/**
+ * Represents the frequency of a tracked word
+ * @author ewang26
+ */
 public class WordCount implements Comparable<WordCount>{
     private String _word;
     private int _count;
-    
+
+    /**
+     * Creates a WordCount of the specific word.
+     * Stores the current count at instantiation.
+     * @param word The word who's frequency is tracked
+     * @param count The frequency of the word
+     */
     public WordCount(String word, int count) {
         _word = word;
         _count = count;
     }
 
+    /**
+     * Gets the tracked word
+     * @return A string representing the tracked word
+     */
     public String getWord() {
         return _word;
     }
 
+    /**
+     * Sets the tracked word
+     * @param _word A string representing the word tracked
+     */
     public void setWord(String _word) {
         this._word = _word;
     }
 
+    /**
+     * Gets the count or frequency of the word
+     * @return A int holding the current frequency of the word
+     */
     public int getCount() {
         return _count;
     }
 
+    /**
+     * Sets and updates the count of the word
+     * @param _count An int representing the new frequency
+     */
     public void setCount(int _count) {
         this._count = _count;
     }
 
+    /**
+     * Increments the count of the word
+     */
     public void increaseCount() {
         this._count++;
     }


### PR DESCRIPTION
I wrote JavaDocs for all completed classes and methods besides "HttpGetAndAnalyze.java", as it seemed defunct and replaced by "AnalyzeNewsMain.java" and "NewsByJsoup.java".
Additionally, I noticed that you sorted by increasing word count in your compareTo method of "WordCount.java" (line 62). I think it might be more helpful for users to see the most frequent words first; I left this for you to decide, though. 