### PR TITLE
Rank and retrieve only the top 20 terms

### DIFF
--- a/src/newsstats/AnalyzeNewsMain.java
+++ b/src/newsstats/AnalyzeNewsMain.java
@@ -1,6 +1,7 @@
 package newsstats;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The AnalyzeNewsMain program implements an application that retrieves content from online news articles
@@ -21,5 +22,10 @@ public class AnalyzeNewsMain {
         NewsAnalyzer analyzer = new NewsAnalyzer(newsList);
         analyzer.countWords();
         analyzer.sortWords();
+
+        //Printing top terms
+        //Issue: https://github.com/ewang26/newsStats/issues/13
+        analyzer.printTopTerms();
+        List<WordCount> topList = analyzer.getTopTerms();
     }
 }

--- a/src/newsstats/NewsAnalyzer.java
+++ b/src/newsstats/NewsAnalyzer.java
@@ -86,6 +86,35 @@ public class NewsAnalyzer {
         wcList.forEach(wc -> System.out.println(wc));
     }
 
+
+    /**
+     * Prints the top 20 terms of the article by number of appearances. If there are less than 20 words in the article,
+     * the method will print all of the words available.
+     */
+    public void printTopTerms(){
+        List<WordCount> topList = getTopTerms();
+        for(WordCount i : topList){
+            System.out.println(i.getWord() + ": " + i.getCount());
+        }
+    }
+
+    /**
+     * Finds and returns the top 20 terms of the article by number of appearances. If there are less than 20 words in the article,
+     * the method will return all of the words available.
+     * @return List of WordCount for the top 20 or less terms of the article by number of appearances
+     */
+    public List<WordCount> getTopTerms(){
+        List<WordCount> wcList = _wcMap.values().stream().collect(Collectors.toList());
+        Collections.sort(wcList);
+        Collections.reverse(wcList);
+
+        List<WordCount> result = new ArrayList<WordCount>();
+        for(int i = 0; i<Math.min(20, wcList.size()); ++i){
+            result.add(wcList.get(i));
+        }
+        return result;
+    }
+
     /**
      * Retrieves the text of the represented news article
      * @return An ArrayList of strings storing text

--- a/src/newsstats/WordCount.java
+++ b/src/newsstats/WordCount.java
@@ -59,6 +59,8 @@ public class WordCount implements Comparable<WordCount>{
     }
 
     public int compareTo(WordCount wc) {
+        //Sorts by increasing (non-decreasing) order of "_count"
+        //Name is not a factor
         if (this._count > wc.getCount()) {
             return 1;
         }
@@ -73,5 +75,6 @@ public class WordCount implements Comparable<WordCount>{
     public String toString() {
         return String.format("Word:%s count %d", _word, _count);
     }
+
 
 }


### PR DESCRIPTION
I created methods in ```NewsAnalyze.java``` to retrieve and print the top 20 most frequently appearing terms. It would, of course, be less if there are fewer than 20 words. I also added an example of its use in ```AnalyzeNewsMain.java```. The issue [Ranking of Most Frequent Terms](https://github.com/ewang26/newsStats/issues/13) suggested implementing this in ```AnalyzeNewsMain.java```, but I didn't understand how this would work, so I decided to do it in the ```NewsAnalyze.java``` class instead. I hope that you find this pull request helpful!